### PR TITLE
Added other.yml file and fixed bug.yml file under .github folder

### DIFF
--- a/.github/ISSUE_TEMPLATE/02-bug.yml
+++ b/.github/ISSUE_TEMPLATE/02-bug.yml
@@ -43,7 +43,6 @@ body:
     attributes:
       label: Relevant Output or Screenshots
       description: Include error logs, stack traces, or screenshots if applicable
-      render: shell
 
   - type: input
     id: environment

--- a/.github/ISSUE_TEMPLATE/03-other.yml
+++ b/.github/ISSUE_TEMPLATE/03-other.yml
@@ -1,0 +1,28 @@
+name: Other
+description: Other issues that are not bugs or feature requests (e.g minor tweaks, code refactoring, documentation updates)
+title: "[Input issue type here]: "
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for issues that don't fit into the Bug Report or Feature Request categories, such as minor tweaks, code refactoring, or documentation updates.
+        Please provide as much detail as possible to help us understand your request.
+
+  - type: input
+    id: summary
+    attributes:
+      label: Issue Summary
+      description: What is the issue you'd like to raise?
+      placeholder: e.g. Code refactoring for better readability
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Describe the issue in detail.
+      placeholder: A detailed explanation of the issue being raised.
+    validations:
+      required: true

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1244,6 +1244,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/cloudinary/-/cloudinary-2.7.0.tgz",
       "integrity": "sha512-qrqDn31+qkMCzKu1GfRpzPNAO86jchcNwEHCUiqvPHNSFqu7FTNF9FuAkBUyvM1CFFgFPu64NT0DyeREwLwK0w==",
+      "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21",
         "q": "^1.5.1"


### PR DESCRIPTION
## 📌 Description

This PR adds other.yml file into .github so users can add issues that do not pertain to features or bugs. It also fixes a bug within the bug.yml template that does not let contributors add screenshots in the Logs section even though it says you can.

It is needed because as it stands, there is no way to raise issues that do not fall under those two pre set categories. It also fixes the bug in the bug.yml template.

---

## 🔗 Related Issue(s)

Closes #71 
Fixes #72 

---

## ✅ Changes

- [ ] Major functionality added
- [✅] Bug fix
- [ ] Refactor
- [ ] Documentation update
- [✅] Other (please describe): Minor functionality in Github for contributors to add Other issues

---

## 🧪 How to Test

N/A
