### PR TITLE
Feature/profile and history

### DIFF
--- a/frontend/src/firebase/firestore.js
+++ b/frontend/src/firebase/firestore.js
@@ -280,3 +280,27 @@ export function formatTimestamp(timestamp) {
     });
   }
 }
+
+/**
+ * Update an item in Firestore
+ * @param {string} itemId - The item's document ID
+ * @param {Object} updateData - The data to update
+ * @returns {Promise<void>}
+ */
+export async function updateItem(itemId, updateData) {
+  try {
+    const itemRef = doc(db, 'items', itemId);
+    
+    // Add updatedAt timestamp
+    const dataToUpdate = {
+      ...updateData,
+      updatedAt: new Date()
+    };
+    
+    await updateDoc(itemRef, dataToUpdate);
+    console.log('Item updated successfully:', itemId);
+  } catch (error) {
+    console.error('Error updating item:', error);
+    throw error;
+  }
+}

--- a/frontend/src/firebase/firestore.js
+++ b/frontend/src/firebase/firestore.js
@@ -216,17 +216,67 @@ export async function updateItemStatus(itemId, newStatus) {
  * @returns {string} Formatted date string
  */
 export function formatTimestamp(timestamp) {
-  if (!timestamp) return 'Unknown date';
+  console.log('formatTimestamp called with:', timestamp, typeof timestamp);
   
-  try {
-    const date = timestamp.toDate ? timestamp.toDate() : new Date(timestamp);
-    return date.toLocaleDateString('en-US', {
+  // If no timestamp provided, return fallback
+  if (!timestamp) {
+    console.log('No timestamp provided, using fallback');
+    return new Date().toLocaleDateString('en-US', {
       year: 'numeric',
       month: 'short', 
       day: 'numeric'
     });
+  }
+  
+  try {
+    let date;
+    
+    // Handle Firestore Timestamp objects
+    if (timestamp.toDate && typeof timestamp.toDate === 'function') {
+      console.log('Using Firestore toDate()');
+      date = timestamp.toDate();
+    }
+    // Handle Firebase Timestamp with seconds property
+    else if (timestamp.seconds) {
+      console.log('Using Firebase seconds:', timestamp.seconds);
+      date = new Date(timestamp.seconds * 1000);
+    }
+    // Handle milliseconds timestamp
+    else if (typeof timestamp === 'number') {
+      console.log('Using number timestamp:', timestamp);
+      date = new Date(timestamp);
+    }
+    // Handle regular Date objects or date strings
+    else {
+      console.log('Using regular Date constructor');
+      date = new Date(timestamp);
+    }
+    
+    // Check if the date is valid
+    if (isNaN(date.getTime())) {
+      console.warn('Invalid timestamp, using current date:', timestamp);
+      return new Date().toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'short', 
+        day: 'numeric'
+      });
+    }
+    
+    const formatted = date.toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short', 
+      day: 'numeric'
+    });
+    
+    console.log('Formatted timestamp:', formatted);
+    return formatted;
+    
   } catch (error) {
-    console.error('Error formatting timestamp:', error);
-    return 'Unknown date';
+    console.error('Error formatting timestamp, using current date:', error, timestamp);
+    return new Date().toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short', 
+      day: 'numeric'
+    });
   }
 }

--- a/frontend/src/firebase/firestore.js
+++ b/frontend/src/firebase/firestore.js
@@ -1,0 +1,99 @@
+import { db } from './config';
+import { collection, query, where, getDocs, doc, getDoc } from 'firebase/firestore';
+
+/**
+ * Fetch user's posted items from Firestore
+ * @param {string} userId - The user's UID
+ * @returns {Promise<Array>} Array of user's posted items
+ */
+export async function getUserPosts(userId) {
+  try {
+    const itemsRef = collection(db, 'items');
+    const q = query(itemsRef, where('postedBy', '==', doc(db, 'users', userId)));
+    const querySnapshot = await getDocs(q);
+    
+    const posts = [];
+    querySnapshot.forEach((doc) => {
+      posts.push({
+        id: doc.id,
+        ...doc.data()
+      });
+    });
+    
+    return posts;
+  } catch (error) {
+    console.error('Error fetching user posts:', error);
+    throw error;
+  }
+}
+
+/**
+ * Fetch items claimed by the user
+ * @param {string} userId - The user's UID
+ * @returns {Promise<Array>} Array of items claimed by the user
+ */
+export async function getUserClaims(userId) {
+  try {
+    const itemsRef = collection(db, 'items');
+    const q = query(itemsRef, where('claimedBy', '==', doc(db, 'users', userId)));
+    const querySnapshot = await getDocs(q);
+    
+    const claims = [];
+    querySnapshot.forEach((doc) => {
+      claims.push({
+        id: doc.id,
+        ...doc.data()
+      });
+    });
+    
+    return claims;
+  } catch (error) {
+    console.error('Error fetching user claims:', error);
+    throw error;
+  }
+}
+
+/**
+ * Get user profile data
+ * @param {string} userId - The user's UID  
+ * @returns {Promise<Object>} User profile data
+ */
+export async function getUserProfile(userId) {
+  try {
+    const userRef = doc(db, 'users', userId);
+    const userSnap = await getDoc(userRef);
+    
+    if (userSnap.exists()) {
+      return {
+        id: userSnap.id,
+        ...userSnap.data()
+      };
+    } else {
+      throw new Error('User not found');
+    }
+  } catch (error) {
+    console.error('Error fetching user profile:', error);
+    throw error;
+  }
+}
+
+/**
+ * Format Firestore timestamp for display
+ * @param {Object} timestamp - Firestore timestamp
+ * @returns {string} Formatted date string
+ */
+export function formatTimestamp(timestamp) {
+  if (!timestamp) return 'Unknown date';
+  
+  try {
+    const date = timestamp.toDate ? timestamp.toDate() : new Date(timestamp);
+    return date.toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short', 
+      day: 'numeric'
+    });
+  } catch (error) {
+    console.error('Error formatting timestamp:', error);
+    return 'Unknown date';
+  }
+}

--- a/frontend/src/firebase/firestore.js
+++ b/frontend/src/firebase/firestore.js
@@ -34,22 +34,131 @@ export async function getUserPosts(userId) {
  */
 export async function getUserClaims(userId) {
   try {
-    const itemsRef = collection(db, 'items');
-    const q = query(itemsRef, where('claimedBy', '==', doc(db, 'users', userId)));
-    const querySnapshot = await getDocs(q);
+    console.log('Fetching claims for user:', userId);
     
-    const claims = [];
-    querySnapshot.forEach((doc) => {
-      claims.push({
-        id: doc.id,
-        ...doc.data()
+    // Method 1: Try to fetch from claims collection
+    try {
+      const claimsRef = collection(db, 'claims');
+      const claimsQuery = query(claimsRef, where('user_id', '==', doc(db, 'users', userId)));
+      const claimsSnapshot = await getDocs(claimsQuery);
+      
+      console.log('Found claims in claims collection:', claimsSnapshot.size);
+      
+      if (claimsSnapshot.size > 0) {
+        const claimedItems = [];
+        
+        // For each claim, fetch the corresponding item
+        for (const claimDoc of claimsSnapshot.docs) {
+          const claimData = claimDoc.data();
+          console.log('Processing claim:', claimDoc.id, claimData);
+          
+          try {
+            // Get the item reference from the claim
+            const itemRef = claimData.item_id;
+            if (itemRef) {
+              const itemDoc = await getDoc(itemRef);
+              if (itemDoc.exists()) {
+                claimedItems.push({
+                  id: itemDoc.id,
+                  ...itemDoc.data(),
+                  claimId: claimDoc.id,
+                  claimData: claimData
+                });
+              }
+            }
+          } catch (itemError) {
+            console.warn('Error fetching item for claim:', claimDoc.id, itemError);
+          }
+        }
+        
+        return claimedItems;
+      }
+    } catch (claimsError) {
+      console.log('Claims collection approach failed:', claimsError);
+    }
+    
+    // Method 2: Try to find items with claimedBy field
+    try {
+      console.log('Trying items with claimedBy field...');
+      const itemsRef = collection(db, 'items');
+      const itemsQuery = query(itemsRef, where('claimedBy', '==', doc(db, 'users', userId)));
+      const itemsSnapshot = await getDocs(itemsQuery);
+      
+      console.log('Found items with claimedBy:', itemsSnapshot.size);
+      
+      const fallbackClaims = [];
+      itemsSnapshot.forEach((doc) => {
+        fallbackClaims.push({
+          id: doc.id,
+          ...doc.data()
+        });
       });
-    });
+      
+      if (fallbackClaims.length > 0) {
+        return fallbackClaims;
+      }
+    } catch (fallbackError) {
+      console.log('ClaimedBy approach failed:', fallbackError);
+    }
     
-    return claims;
+    // Method 3: Check all items and look for claims array/subcollection
+    try {
+      console.log('Checking all items for claims array...');
+      const itemsRef = collection(db, 'items');
+      const allItemsSnapshot = await getDocs(itemsRef);
+      
+      const claimedItems = [];
+      
+      for (const itemDoc of allItemsSnapshot.docs) {
+        const itemData = itemDoc.data();
+        
+        // Check if item has claims array
+        if (itemData.claims && Array.isArray(itemData.claims)) {
+          const userClaim = itemData.claims.find(claim => 
+            claim.user_id && claim.user_id.path === `users/${userId}`
+          );
+          
+          if (userClaim) {
+            claimedItems.push({
+              id: itemDoc.id,
+              ...itemData,
+              userClaim: userClaim
+            });
+          }
+        }
+        
+        // Also check for claims subcollection
+        try {
+          const claimsSubRef = collection(itemDoc.ref, 'claims');
+          const userClaimQuery = query(claimsSubRef, where('user_id', '==', doc(db, 'users', userId)));
+          const userClaimSnapshot = await getDocs(userClaimQuery);
+          
+          if (userClaimSnapshot.size > 0) {
+            claimedItems.push({
+              id: itemDoc.id,
+              ...itemData,
+              userClaims: userClaimSnapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }))
+            });
+          }
+        } catch (subError) {
+          // Subcollection doesn't exist or access denied, skip
+        }
+      }
+      
+      console.log('Found items with claims:', claimedItems.length);
+      return claimedItems;
+      
+    } catch (allItemsError) {
+      console.error('All items approach failed:', allItemsError);
+    }
+    
+    // If all methods fail, return empty array
+    console.log('All claim fetching methods failed, returning empty array');
+    return [];
+    
   } catch (error) {
     console.error('Error fetching user claims:', error);
-    throw error;
+    return [];
   }
 }
 

--- a/frontend/src/lib/mock-data.js
+++ b/frontend/src/lib/mock-data.js
@@ -62,19 +62,71 @@ export function getItemsClient() {
 
 export function getProfileItems() {
   return [
+    // Items posted by the current user (Guest User)
     {
       id: "1",
       title: "Lost: Black iPhone 13",
       status: "Open",
+      kind: "lost",
+      category: "electronics",
+      reporter: { name: "Guest User" },
+      claims: [
+        { id: "claim1", claimer: "John Doe", status: "pending", date: new Date(Date.now() - 86400000).toISOString() }
+      ]
+    },
+    {
+      id: "3",
+      title: "Lost: Student ID Card",
+      status: "Resolved", 
+      kind: "lost",
+      category: "card",
+      reporter: { name: "Guest User" },
+      claims: [
+        { id: "claim2", claimer: "Sarah Kim", status: "approved", date: new Date(Date.now() - 172800000).toISOString() }
+      ]
+    },
+    {
+      id: "5",
+      title: "Found: Blue Water Bottle",
+      status: "Unclaimed",
+      kind: "found", 
+      category: "accessory",
       reporter: { name: "Guest User" },
       claims: []
     },
+    // Items posted by others that current user has claimed
     {
       id: "2", 
-      title: "Found AirPods",
-      status: "Unclaimed",
+      title: "Found: AirPods Pro",
+      status: "Claimed",
+      kind: "found",
+      category: "electronics", 
       reporter: { name: "John Doe" },
-      claims: []
+      claims: [
+        { id: "claim3", claimer: "Guest User", status: "pending", date: new Date(Date.now() - 43200000).toISOString() }
+      ]
+    },
+    {
+      id: "4",
+      title: "Found: Grey Hoodie",
+      status: "Resolved",
+      kind: "found",
+      category: "apparel",
+      reporter: { name: "Mike Wilson" },
+      claims: [
+        { id: "claim4", claimer: "Guest User", status: "approved", date: new Date(Date.now() - 259200000).toISOString() }
+      ]
+    },
+    {
+      id: "6",
+      title: "Found: Red Notebook",
+      status: "Claimed",
+      kind: "found", 
+      category: "other",
+      reporter: { name: "Emma Davis" },
+      claims: [
+        { id: "claim5", claimer: "Guest User", status: "rejected", date: new Date(Date.now() - 604800000).toISOString() }
+      ]
     }
   ]
 }

--- a/frontend/src/pages/ProfilePage.js
+++ b/frontend/src/pages/ProfilePage.js
@@ -163,8 +163,20 @@ export default function ProfilePage() {
                         const badge = getStatusBadge(item, true)
                         
                         return (
-                          <div key={item.id} className="flex justify-between items-start p-3 bg-gray-50 rounded-lg cursor-pointer hover:bg-gray-100"
-                               onClick={() => navigate(`/item/${item.id}`)}>
+                          <div 
+                            key={item.id} 
+                            className="flex justify-between items-start p-3 bg-gray-50 rounded-lg cursor-pointer hover:bg-gray-100 hover:shadow-sm transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                            onClick={() => navigate(`/items/${item.id}`)}
+                            onKeyDown={(e) => {
+                              if (e.key === 'Enter' || e.key === ' ') {
+                                e.preventDefault()
+                                navigate(`/items/${item.id}`)
+                              }
+                            }}
+                            tabIndex={0}
+                            role="button"
+                            aria-label={`View details for ${item.title || 'Untitled Item'}`}
+                          >
                             <div className="flex-1">
                               <div className="flex items-center gap-2 mb-1">
                                 <span className="text-sm font-medium text-gray-900">{item.title || 'Untitled Item'}</span>
@@ -207,8 +219,20 @@ export default function ProfilePage() {
                         const badge = getStatusBadge(item, false)
                         
                         return (
-                          <div key={item.id} className="flex justify-between items-start p-3 bg-gray-50 rounded-lg cursor-pointer hover:bg-gray-100"
-                               onClick={() => navigate(`/item/${item.id}`)}>
+                          <div 
+                            key={item.id} 
+                            className="flex justify-between items-start p-3 bg-gray-50 rounded-lg cursor-pointer hover:bg-gray-100 hover:shadow-sm transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                            onClick={() => navigate(`/items/${item.id}`)}
+                            onKeyDown={(e) => {
+                              if (e.key === 'Enter' || e.key === ' ') {
+                                e.preventDefault()
+                                navigate(`/items/${item.id}`)
+                              }
+                            }}
+                            tabIndex={0}
+                            role="button"
+                            aria-label={`View details for ${item.title || 'Untitled Item'}`}
+                          >
                             <div className="flex-1">
                               <div className="flex items-center gap-2 mb-1">
                                 <span className="text-sm font-medium text-gray-900">{item.title || 'Untitled Item'}</span>

--- a/frontend/src/pages/ProfilePage.js
+++ b/frontend/src/pages/ProfilePage.js
@@ -24,10 +24,15 @@ export default function ProfilePage() {
       
       try {
         setLoading(true)
+        console.log('Fetching data for user:', currentUser.uid)
+        
         const [posts, claims] = await Promise.all([
           getUserPosts(currentUser.uid),
           getUserClaims(currentUser.uid)
         ])
+        
+        console.log('Fetched posts:', posts)
+        console.log('Fetched claims:', claims)
         
         setMyPosts(posts)
         setMyClaims(claims)
@@ -53,6 +58,8 @@ export default function ProfilePage() {
           return { variant: 'default', text: 'Resolved', color: 'bg-green-100 text-green-800' }
         case 'claimed':
           return { variant: 'secondary', text: 'Claimed', color: 'bg-purple-100 text-purple-800' }
+        case 'pending':
+          return { variant: 'secondary', text: 'Pending', color: 'bg-orange-100 text-orange-800' }
         case 'lost':
         case 'open':
         case 'active':
@@ -60,8 +67,18 @@ export default function ProfilePage() {
           return { variant: 'secondary', text: 'Active', color: 'bg-blue-100 text-blue-800' }
       }
     } else {
-      // For claims by the user - assume pending for now since we don't have claim status in current schema
-      return { variant: 'secondary', text: 'Claimed', color: 'bg-orange-100 text-orange-800' }
+      // For claims by the user - show the claim status (pending/approved/rejected)
+      const claimStatus = item.claimData?.status || item.status || 'pending'
+      switch (claimStatus.toLowerCase()) {
+        case 'pending':
+          return { variant: 'secondary', text: 'Pending', color: 'bg-orange-100 text-orange-800' }
+        case 'approved':
+          return { variant: 'default', text: 'Approved', color: 'bg-green-100 text-green-800' }
+        case 'rejected':
+          return { variant: 'outline', text: 'Rejected', color: 'bg-red-100 text-red-800' }
+        default:
+          return { variant: 'secondary', text: 'Pending', color: 'bg-orange-100 text-orange-800' }
+      }
     }
   }
   
@@ -186,6 +203,7 @@ export default function ProfilePage() {
                       <p className="text-sm text-gray-500">No claims yet. Browse the feed to claim items you've lost!</p>
                     ) : (
                       myClaims.map((item) => {
+                        // For claims, show the claim status (pending/approved/rejected)
                         const badge = getStatusBadge(item, false)
                         
                         return (

--- a/frontend/src/pages/ProfilePage.js
+++ b/frontend/src/pages/ProfilePage.js
@@ -173,9 +173,9 @@ export default function ProfilePage() {
                                 </span>
                               </div>
                               <div className="flex items-center gap-4 text-xs text-gray-500">
-                                <span className={`px-2 py-1 rounded-full ${
-                                  item.status === 'lost' ? 'bg-red-100 text-red-700' : 'bg-blue-100 text-blue-700'
-                                }`}>
+                                <span className={
+                                  item.status === 'lost' ? 'text-red-700' : 'text-blue-700'
+                                }>
                                   {item.status === 'lost' ? 'Lost Item' : 'Found Item'}
                                 </span>
                                 <span>{formatTimestamp(item.createdAt)}</span>
@@ -217,9 +217,9 @@ export default function ProfilePage() {
                                 </span>
                               </div>
                               <div className="flex items-center gap-4 text-xs text-gray-500">
-                                <span className={`px-2 py-1 rounded-full ${
-                                  item.status === 'lost' ? 'bg-red-100 text-red-700' : 'bg-blue-100 text-blue-700'
-                                }`}>
+                                <span className={
+                                  item.status === 'lost' ? 'text-red-700' : 'text-blue-700'
+                                }>
                                   {item.status === 'lost' ? 'Lost Item' : 'Found Item'}
                                 </span>
                                 <span>{formatTimestamp(item.createdAt)}</span>

--- a/frontend/src/pages/ProfilePage.js
+++ b/frontend/src/pages/ProfilePage.js
@@ -1,63 +1,71 @@
-import React, { useMemo } from "react"
+import React, { useState, useEffect } from "react"
 import { useNavigate } from "react-router-dom"
 import { getAuth, signOut } from "firebase/auth"
 import { LogOut } from "lucide-react"
-import { getProfileItems } from "../lib/mock-data"
+import { getUserPosts, getUserClaims, formatTimestamp } from "../firebase/firestore"
 import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/card"
 import { ProfileBadge } from '../components/ui/ProfileBadge'
-import Badge from '../components/ui/Badge'
 
 export default function ProfilePage() {
-  // Get mock data for now - will be replaced with real user data
-  const items = getProfileItems()
-  const myName = "Guest User"
+  const [myPosts, setMyPosts] = useState([])
+  const [myClaims, setMyClaims] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const auth = getAuth()
+  const currentUser = auth.currentUser
   
-  // Filter items based on current user
-  const myPosts = useMemo(() => items.filter((i) => i.reporter.name === myName), [items])
-  const myClaims = useMemo(() => items.filter((i) => i.claims.some((c) => c.claimer === myName)), [items])
+  // Fetch user's posts and claims from Firestore
+  useEffect(() => {
+    const fetchUserData = async () => {
+      if (!currentUser) {
+        setLoading(false)
+        return
+      }
+      
+      try {
+        setLoading(true)
+        const [posts, claims] = await Promise.all([
+          getUserPosts(currentUser.uid),
+          getUserClaims(currentUser.uid)
+        ])
+        
+        setMyPosts(posts)
+        setMyClaims(claims)
+      } catch (err) {
+        console.error('Error fetching user data:', err)
+        setError('Failed to load your data. Please try again.')
+      } finally {
+        setLoading(false)
+      }
+    }
+    
+    fetchUserData()
+  }, [currentUser])
 
   // Helper function to get status badge variant and text
-  const getStatusBadge = (status, kind, claims, isMyPost = false) => {
+  const getStatusBadge = (item, isMyPost = false) => {
     if (isMyPost) {
       // For posts by the user
-      switch (status) {
-        case 'Open':
-          return { variant: 'secondary', text: 'Open', color: 'bg-blue-100 text-blue-800' }
-        case 'Unclaimed':
-          return { variant: 'secondary', text: 'Unclaimed', color: 'bg-yellow-100 text-yellow-800' }
-        case 'Resolved':
+      const status = item.status || 'open'
+      switch (status.toLowerCase()) {
+        case 'found':
+        case 'resolved':
           return { variant: 'default', text: 'Resolved', color: 'bg-green-100 text-green-800' }
-        case 'Claimed':
-          const hasPendingClaims = claims.some(c => c.status === 'pending')
-          return { 
-            variant: 'secondary', 
-            text: hasPendingClaims ? 'Pending Review' : 'Claimed',
-            color: hasPendingClaims ? 'bg-orange-100 text-orange-800' : 'bg-purple-100 text-purple-800'
-          }
+        case 'claimed':
+          return { variant: 'secondary', text: 'Claimed', color: 'bg-purple-100 text-purple-800' }
+        case 'lost':
+        case 'open':
+        case 'active':
         default:
-          return { variant: 'outline', text: status, color: 'bg-gray-100 text-gray-800' }
+          return { variant: 'secondary', text: 'Active', color: 'bg-blue-100 text-blue-800' }
       }
     } else {
-      // For claims by the user
-      const myClaim = claims.find(c => c.claimer === myName)
-      if (myClaim) {
-        switch (myClaim.status) {
-          case 'pending':
-            return { variant: 'secondary', text: 'Pending', color: 'bg-orange-100 text-orange-800' }
-          case 'approved':
-            return { variant: 'default', text: 'Approved', color: 'bg-green-100 text-green-800' }
-          case 'rejected':
-            return { variant: 'outline', text: 'Rejected', color: 'bg-red-100 text-red-800' }
-          default:
-            return { variant: 'outline', text: 'Unknown', color: 'bg-gray-100 text-gray-800' }
-        }
-      }
-      return { variant: 'outline', text: 'No Claim', color: 'bg-gray-100 text-gray-800' }
+      // For claims by the user - assume pending for now since we don't have claim status in current schema
+      return { variant: 'secondary', text: 'Claimed', color: 'bg-orange-100 text-orange-800' }
     }
   }
   
   const navigate = useNavigate()
-  const auth = getAuth()
 
   // Handle user logout
   const handleLogout = async () => {
@@ -80,7 +88,7 @@ export default function ProfilePage() {
             <div>
               <h1 className="text-3xl font-bold text-gray-900">Profile & History</h1>
               <p className="text-gray-600 mt-2">
-                Mock user context. Integrate UPI-backed SSO for identity and trust badges (A2).
+                Welcome back, {currentUser?.displayName || currentUser?.email || 'User'}!
               </p>
             </div>
             {/* Logout button - red to indicate destructive action */}
@@ -106,92 +114,111 @@ export default function ProfilePage() {
             </CardContent>
           </Card>
 
-          {/* User activity grid - posts and claims */}
-          <div className="grid md:grid-cols-2 gap-6">
-            {/* Items this user has posted */}
-            <Card>
-              <CardHeader>
-                <CardTitle>
-                  My Posts ({myPosts.length})
-                </CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-3">
-                {myPosts.length === 0 ? (
-                  <p className="text-sm text-gray-500">No posts yet. Start by reporting a lost or found item!</p>
-                ) : (
-                  myPosts.map((item) => {
-                    const badge = getStatusBadge(item.status, item.kind, item.claims, true)
-                    const pendingClaims = item.claims.filter(c => c.status === 'pending').length
-                    
-                    return (
-                      <div key={item.id} className="flex justify-between items-start p-3 bg-gray-50 rounded-lg">
-                        <div className="flex-1">
-                          <div className="flex items-center gap-2 mb-1">
-                            <span className="text-sm font-medium text-gray-900">{item.title}</span>
-                            <span className={`inline-flex items-center rounded-full px-2 py-1 text-xs font-medium ${badge.color}`}>
-                              {badge.text}
-                            </span>
-                          </div>
-                          <div className="flex items-center gap-4 text-xs text-gray-500">
-                            <span className={`px-2 py-1 rounded-full ${
-                              item.kind === 'lost' ? 'bg-red-100 text-red-700' : 'bg-blue-100 text-blue-700'
-                            }`}>
-                              {item.kind === 'lost' ? 'Lost Item' : 'Found Item'}
-                            </span>
-                            {pendingClaims > 0 && (
-                              <span className="text-orange-600 font-medium">
-                                {pendingClaims} pending claim{pendingClaims !== 1 ? 's' : ''}
-                              </span>
-                            )}
-                          </div>
-                        </div>
-                      </div>
-                    )
-                  })
-                )}
-              </CardContent>
-            </Card>
+          {/* Loading and Error States */}
+          {loading && (
+            <div className="text-center py-8">
+              <p className="text-gray-500">Loading your data...</p>
+            </div>
+          )}
+          
+          {error && (
+            <div className="bg-red-50 border border-red-200 rounded-lg p-4 mb-6">
+              <p className="text-red-700">{error}</p>
+            </div>
+          )}
 
-            {/* Items this user has claimed */}
-            <Card>
-              <CardHeader>
-                <CardTitle>
-                  My Claims ({myClaims.length})
-                </CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-3">
-                {myClaims.length === 0 ? (
-                  <p className="text-sm text-gray-500">No claims yet. Browse the feed to claim items you've lost!</p>
-                ) : (
-                  myClaims.map((item) => {
-                    const badge = getStatusBadge(item.status, item.kind, item.claims, false)
-                    const myClaim = item.claims.find(c => c.claimer === myName)
-                    
-                    return (
-                      <div key={item.id} className="flex justify-between items-start p-3 bg-gray-50 rounded-lg">
-                        <div className="flex-1">
-                          <div className="flex items-center gap-2 mb-1">
-                            <span className="text-sm font-medium text-gray-900">{item.title}</span>
-                            <span className={`inline-flex items-center rounded-full px-2 py-1 text-xs font-medium ${badge.color}`}>
-                              {badge.text}
-                            </span>
+          {!loading && !error && (
+            <>
+              {/* User activity grid - posts and claims */}
+              <div className="grid md:grid-cols-2 gap-6">
+                {/* Items this user has posted */}
+                <Card>
+                  <CardHeader>
+                    <CardTitle>
+                      My Posts ({myPosts.length})
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-3">
+                    {myPosts.length === 0 ? (
+                      <p className="text-sm text-gray-500">No posts yet. Start by reporting a lost or found item!</p>
+                    ) : (
+                      myPosts.map((item) => {
+                        const badge = getStatusBadge(item, true)
+                        
+                        return (
+                          <div key={item.id} className="flex justify-between items-start p-3 bg-gray-50 rounded-lg cursor-pointer hover:bg-gray-100"
+                               onClick={() => navigate(`/item/${item.id}`)}>
+                            <div className="flex-1">
+                              <div className="flex items-center gap-2 mb-1">
+                                <span className="text-sm font-medium text-gray-900">{item.title || 'Untitled Item'}</span>
+                                <span className={`inline-flex items-center rounded-full px-2 py-1 text-xs font-medium ${badge.color}`}>
+                                  {badge.text}
+                                </span>
+                              </div>
+                              <div className="flex items-center gap-4 text-xs text-gray-500">
+                                <span className={`px-2 py-1 rounded-full ${
+                                  item.status === 'lost' ? 'bg-red-100 text-red-700' : 'bg-blue-100 text-blue-700'
+                                }`}>
+                                  {item.status === 'lost' ? 'Lost Item' : 'Found Item'}
+                                </span>
+                                <span>{formatTimestamp(item.createdAt)}</span>
+                                {item.location && (
+                                  <span>📍 {item.location}</span>
+                                )}
+                              </div>
+                            </div>
                           </div>
-                          <div className="flex items-center gap-4 text-xs text-gray-500">
-                            <span>Posted by {item.reporter.name}</span>
-                            {myClaim && (
-                              <span>
-                                Claimed {new Date(myClaim.date).toLocaleDateString()}
-                              </span>
-                            )}
+                        )
+                      })
+                    )}
+                  </CardContent>
+                </Card>
+
+                {/* Items this user has claimed */}
+                <Card>
+                  <CardHeader>
+                    <CardTitle>
+                      My Claims ({myClaims.length})
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-3">
+                    {myClaims.length === 0 ? (
+                      <p className="text-sm text-gray-500">No claims yet. Browse the feed to claim items you've lost!</p>
+                    ) : (
+                      myClaims.map((item) => {
+                        const badge = getStatusBadge(item, false)
+                        
+                        return (
+                          <div key={item.id} className="flex justify-between items-start p-3 bg-gray-50 rounded-lg cursor-pointer hover:bg-gray-100"
+                               onClick={() => navigate(`/item/${item.id}`)}>
+                            <div className="flex-1">
+                              <div className="flex items-center gap-2 mb-1">
+                                <span className="text-sm font-medium text-gray-900">{item.title || 'Untitled Item'}</span>
+                                <span className={`inline-flex items-center rounded-full px-2 py-1 text-xs font-medium ${badge.color}`}>
+                                  {badge.text}
+                                </span>
+                              </div>
+                              <div className="flex items-center gap-4 text-xs text-gray-500">
+                                <span className={`px-2 py-1 rounded-full ${
+                                  item.status === 'lost' ? 'bg-red-100 text-red-700' : 'bg-blue-100 text-blue-700'
+                                }`}>
+                                  {item.status === 'lost' ? 'Lost Item' : 'Found Item'}
+                                </span>
+                                <span>{formatTimestamp(item.createdAt)}</span>
+                                {item.location && (
+                                  <span>📍 {item.location}</span>
+                                )}
+                              </div>
+                            </div>
                           </div>
-                        </div>
-                      </div>
-                    )
-                  })
-                )}
-              </CardContent>
-            </Card>
-          </div>
+                        )
+                      })
+                    )}
+                  </CardContent>
+                </Card>
+              </div>
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/src/pages/ProfilePage.js
+++ b/frontend/src/pages/ProfilePage.js
@@ -34,6 +34,17 @@ export default function ProfilePage() {
         console.log('Fetched posts:', posts)
         console.log('Fetched claims:', claims)
         
+        // Debug timestamp fields
+        if (posts.length > 0) {
+          console.log('First post timestamp fields:', {
+            createdAt: posts[0].createdAt,
+            created_at: posts[0].created_at,
+            timestamp: posts[0].timestamp,
+            dateCreated: posts[0].dateCreated,
+            updatedAt: posts[0].updatedAt
+          });
+        }
+        
         setMyPosts(posts)
         setMyClaims(claims)
       } catch (err) {
@@ -224,7 +235,7 @@ export default function ProfilePage() {
                                 }>
                                   {item.status === 'lost' ? 'Lost Item' : 'Found Item'}
                                 </span>
-                                <span>{formatTimestamp(item.createdAt)}</span>
+                                <span>📅 {formatTimestamp(item.createdAt || item.created_at || item.timestamp || item.dateCreated)}</span>
                                 {item.location && (
                                   <span>📍 {item.location}</span>
                                 )}
@@ -295,7 +306,7 @@ export default function ProfilePage() {
                                 }>
                                   {item.status === 'lost' ? 'Lost Item' : 'Found Item'}
                                 </span>
-                                <span>{formatTimestamp(item.createdAt)}</span>
+                                <span>📅 {formatTimestamp(item.createdAt || item.created_at || item.timestamp || item.dateCreated)}</span>
                                 {item.location && (
                                   <span>📍 {item.location}</span>
                                 )}

--- a/frontend/src/pages/ProfilePage.js
+++ b/frontend/src/pages/ProfilePage.js
@@ -5,6 +5,7 @@ import { LogOut } from "lucide-react"
 import { getProfileItems } from "../lib/mock-data"
 import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/card"
 import { ProfileBadge } from '../components/ui/ProfileBadge'
+import Badge from '../components/ui/Badge'
 
 export default function ProfilePage() {
   // Get mock data for now - will be replaced with real user data
@@ -14,6 +15,46 @@ export default function ProfilePage() {
   // Filter items based on current user
   const myPosts = useMemo(() => items.filter((i) => i.reporter.name === myName), [items])
   const myClaims = useMemo(() => items.filter((i) => i.claims.some((c) => c.claimer === myName)), [items])
+
+  // Helper function to get status badge variant and text
+  const getStatusBadge = (status, kind, claims, isMyPost = false) => {
+    if (isMyPost) {
+      // For posts by the user
+      switch (status) {
+        case 'Open':
+          return { variant: 'secondary', text: 'Open', color: 'bg-blue-100 text-blue-800' }
+        case 'Unclaimed':
+          return { variant: 'secondary', text: 'Unclaimed', color: 'bg-yellow-100 text-yellow-800' }
+        case 'Resolved':
+          return { variant: 'default', text: 'Resolved', color: 'bg-green-100 text-green-800' }
+        case 'Claimed':
+          const hasPendingClaims = claims.some(c => c.status === 'pending')
+          return { 
+            variant: 'secondary', 
+            text: hasPendingClaims ? 'Pending Review' : 'Claimed',
+            color: hasPendingClaims ? 'bg-orange-100 text-orange-800' : 'bg-purple-100 text-purple-800'
+          }
+        default:
+          return { variant: 'outline', text: status, color: 'bg-gray-100 text-gray-800' }
+      }
+    } else {
+      // For claims by the user
+      const myClaim = claims.find(c => c.claimer === myName)
+      if (myClaim) {
+        switch (myClaim.status) {
+          case 'pending':
+            return { variant: 'secondary', text: 'Pending', color: 'bg-orange-100 text-orange-800' }
+          case 'approved':
+            return { variant: 'default', text: 'Approved', color: 'bg-green-100 text-green-800' }
+          case 'rejected':
+            return { variant: 'outline', text: 'Rejected', color: 'bg-red-100 text-red-800' }
+          default:
+            return { variant: 'outline', text: 'Unknown', color: 'bg-gray-100 text-gray-800' }
+        }
+      }
+      return { variant: 'outline', text: 'No Claim', color: 'bg-gray-100 text-gray-800' }
+    }
+  }
   
   const navigate = useNavigate()
   const auth = getAuth()
@@ -70,18 +111,43 @@ export default function ProfilePage() {
             {/* Items this user has posted */}
             <Card>
               <CardHeader>
-                <CardTitle>My Posts</CardTitle>
+                <CardTitle>
+                  My Posts ({myPosts.length})
+                </CardTitle>
               </CardHeader>
-              <CardContent className="space-y-2">
+              <CardContent className="space-y-3">
                 {myPosts.length === 0 ? (
-                  <p className="text-sm text-gray-500">No posts yet.</p>
+                  <p className="text-sm text-gray-500">No posts yet. Start by reporting a lost or found item!</p>
                 ) : (
-                  myPosts.map((i) => (
-                    <div key={i.id} className="flex justify-between items-center text-sm">
-                      <span className="text-gray-900">{i.title}</span>
-                      <span className="text-green-600 font-medium">Open</span>
-                    </div>
-                  ))
+                  myPosts.map((item) => {
+                    const badge = getStatusBadge(item.status, item.kind, item.claims, true)
+                    const pendingClaims = item.claims.filter(c => c.status === 'pending').length
+                    
+                    return (
+                      <div key={item.id} className="flex justify-between items-start p-3 bg-gray-50 rounded-lg">
+                        <div className="flex-1">
+                          <div className="flex items-center gap-2 mb-1">
+                            <span className="text-sm font-medium text-gray-900">{item.title}</span>
+                            <span className={`inline-flex items-center rounded-full px-2 py-1 text-xs font-medium ${badge.color}`}>
+                              {badge.text}
+                            </span>
+                          </div>
+                          <div className="flex items-center gap-4 text-xs text-gray-500">
+                            <span className={`px-2 py-1 rounded-full ${
+                              item.kind === 'lost' ? 'bg-red-100 text-red-700' : 'bg-blue-100 text-blue-700'
+                            }`}>
+                              {item.kind === 'lost' ? 'Lost Item' : 'Found Item'}
+                            </span>
+                            {pendingClaims > 0 && (
+                              <span className="text-orange-600 font-medium">
+                                {pendingClaims} pending claim{pendingClaims !== 1 ? 's' : ''}
+                              </span>
+                            )}
+                          </div>
+                        </div>
+                      </div>
+                    )
+                  })
                 )}
               </CardContent>
             </Card>
@@ -89,18 +155,39 @@ export default function ProfilePage() {
             {/* Items this user has claimed */}
             <Card>
               <CardHeader>
-                <CardTitle>My Claims</CardTitle>
+                <CardTitle>
+                  My Claims ({myClaims.length})
+                </CardTitle>
               </CardHeader>
-              <CardContent className="space-y-2">
+              <CardContent className="space-y-3">
                 {myClaims.length === 0 ? (
-                  <p className="text-sm text-gray-500">No claims yet.</p>
+                  <p className="text-sm text-gray-500">No claims yet. Browse the feed to claim items you've lost!</p>
                 ) : (
-                  myClaims.map((i) => (
-                    <div key={i.id} className="flex justify-between items-center text-sm">
-                      <span className="text-gray-900">{i.title}</span>
-                      <span className="text-gray-500">{i.status}</span>
-                    </div>
-                  ))
+                  myClaims.map((item) => {
+                    const badge = getStatusBadge(item.status, item.kind, item.claims, false)
+                    const myClaim = item.claims.find(c => c.claimer === myName)
+                    
+                    return (
+                      <div key={item.id} className="flex justify-between items-start p-3 bg-gray-50 rounded-lg">
+                        <div className="flex-1">
+                          <div className="flex items-center gap-2 mb-1">
+                            <span className="text-sm font-medium text-gray-900">{item.title}</span>
+                            <span className={`inline-flex items-center rounded-full px-2 py-1 text-xs font-medium ${badge.color}`}>
+                              {badge.text}
+                            </span>
+                          </div>
+                          <div className="flex items-center gap-4 text-xs text-gray-500">
+                            <span>Posted by {item.reporter.name}</span>
+                            {myClaim && (
+                              <span>
+                                Claimed {new Date(myClaim.date).toLocaleDateString()}
+                              </span>
+                            )}
+                          </div>
+                        </div>
+                      </div>
+                    )
+                  })
                 )}
               </CardContent>
             </Card>

--- a/frontend/src/pages/ProfilePage.js
+++ b/frontend/src/pages/ProfilePage.js
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from "react"
 import { useNavigate } from "react-router-dom"
 import { getAuth, signOut } from "firebase/auth"
-import { LogOut, Trash2 } from "lucide-react"
-import { getUserPosts, getUserClaims, formatTimestamp, updateItemStatus } from "../firebase/firestore"
+import { LogOut, Trash2, Edit3, X } from "lucide-react"
+import { getUserPosts, getUserClaims, formatTimestamp, updateItemStatus, updateItem } from "../firebase/firestore"
 import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/card"
 import { ProfileBadge } from '../components/ui/ProfileBadge'
 
@@ -10,6 +10,18 @@ export default function ProfilePage() {
   const [myPosts, setMyPosts] = useState([])
   const [myClaims, setMyClaims] = useState([])
   const [loading, setLoading] = useState(true)
+  const [editModalOpen, setEditModalOpen] = useState(false)
+  const [editingItem, setEditingItem] = useState(null)
+  const [editFormData, setEditFormData] = useState({
+    title: '',
+    description: '',
+    category: '',
+    location: '',
+    kind: '', // lost or found
+    imageUrl: '',
+    date: '',
+    time: ''
+  })
   const [error, setError] = useState(null)
   const auth = getAuth()
   const currentUser = auth.currentUser
@@ -126,6 +138,117 @@ export default function ProfilePage() {
     }
   }
 
+  // Handle editing a post
+  const handleEditPost = (item) => {
+    // Parse existing date/time if available
+    let dateValue = ''
+    let timeValue = ''
+    
+    // Firebase uses 'date' field for the actual lost/found date/time
+    if (item.date || item.createdAt || item.created_at || item.timestamp || item.dateCreated) {
+      try {
+        const existingDate = new Date(item.date || item.createdAt || item.created_at || item.timestamp || item.dateCreated)
+        if (!isNaN(existingDate.getTime())) {
+          dateValue = existingDate.toISOString().split('T')[0] // YYYY-MM-DD format
+          timeValue = existingDate.toTimeString().split(' ')[0].slice(0, 5) // HH:MM format
+        }
+      } catch (error) {
+        console.log('Error parsing existing date:', error)
+      }
+    }
+    
+    setEditingItem(item)
+    setEditFormData({
+      title: item.title || '',
+      description: item.description || '',
+      category: item.type || item.category || '', // Firebase uses 'type' field
+      location: item.location || '',
+      kind: item.status?.toLowerCase() || item.kind || 'lost', // Firebase uses 'status' for lost/found
+      imageUrl: item.imageURL || item.imageUrl || item.image || '', // Firebase uses 'imageURL'
+      date: dateValue,
+      time: timeValue
+    })
+    setEditModalOpen(true)
+  }
+
+  // Handle closing edit modal
+  const handleCloseEditModal = () => {
+    setEditModalOpen(false)
+    setEditingItem(null)
+    setEditFormData({
+      title: '',
+      description: '',
+      category: '',
+      location: '',
+      kind: '',
+      imageUrl: '',
+      date: '',
+      time: ''
+    })
+  }
+
+  // Handle form input changes
+  const handleFormChange = (field, value) => {
+    setEditFormData(prev => ({
+      ...prev,
+      [field]: value
+    }))
+  }
+
+  // Handle saving edited post
+  const handleSaveEdit = async () => {
+    if (!editingItem || !editFormData.title.trim()) {
+      alert('Please fill in at least the title field.')
+      return
+    }
+
+    try {
+      // Combine date and time into a single timestamp
+      let combinedDateTime = null
+      if (editFormData.date) {
+        const dateTimeString = editFormData.time 
+          ? `${editFormData.date}T${editFormData.time}:00`
+          : `${editFormData.date}T00:00:00`
+        combinedDateTime = new Date(dateTimeString)
+      }
+
+      // Prepare update data (using Firebase field names)
+      const updateData = {
+        title: editFormData.title.trim(),
+        description: editFormData.description.trim(),
+        type: editFormData.category, // Firebase uses 'type' for category
+        location: editFormData.location,
+        status: editFormData.kind, // Firebase uses 'status' for lost/found
+        imageURL: editFormData.imageUrl.trim() // Firebase uses 'imageURL'
+      }
+
+      // Add date if provided (only update the date field, not createdAt)
+      if (combinedDateTime && !isNaN(combinedDateTime.getTime())) {
+        updateData.date = combinedDateTime.toISOString()
+        // Note: Do NOT update createdAt - it should remain the original creation time
+      }
+
+      // Update the item in Firebase
+      await updateItem(editingItem.id, updateData)
+      
+      // Refresh data from Firebase to ensure consistency
+      if (currentUser) {
+        const [posts, claims] = await Promise.all([
+          getUserPosts(currentUser.uid),
+          getUserClaims(currentUser.uid)
+        ])
+        setMyPosts(posts)
+        setMyClaims(claims)
+      }
+      
+      handleCloseEditModal()
+      alert('Post updated successfully!')
+    } catch (error) {
+      console.error('Error updating post:', error)
+      alert('Failed to update post. Please try again.')
+    }
+  }
+
   // Handle user logout
   const handleLogout = async () => {
     try {
@@ -235,12 +358,27 @@ export default function ProfilePage() {
                                 }>
                                   {item.status === 'lost' ? 'Lost Item' : 'Found Item'}
                                 </span>
-                                <span>📅 {formatTimestamp(item.createdAt || item.created_at || item.timestamp || item.dateCreated)}</span>
+                                <span>📅 {formatTimestamp(item.date || item.createdAt || item.created_at || item.timestamp || item.dateCreated)}</span>
                                 {item.location && (
                                   <span>📍 {item.location}</span>
                                 )}
                               </div>
                             </div>
+                            
+                            {/* Edit button - only show for non-resolved items */}
+                            {!isResolved && (
+                              <button
+                                onClick={(e) => {
+                                  e.stopPropagation() // Prevent navigation when clicking edit button
+                                  handleEditPost(item)
+                                }}
+                                className="ml-2 p-1 text-gray-400 hover:text-blue-600 hover:bg-blue-50 rounded transition-colors"
+                                title="Edit this post"
+                                aria-label="Edit post"
+                              >
+                                <Edit3 className="w-4 h-4" />
+                              </button>
+                            )}
                             
                             {/* Close button - only show for non-resolved items */}
                             {!isResolved && (
@@ -306,7 +444,7 @@ export default function ProfilePage() {
                                 }>
                                   {item.status === 'lost' ? 'Lost Item' : 'Found Item'}
                                 </span>
-                                <span>📅 {formatTimestamp(item.createdAt || item.created_at || item.timestamp || item.dateCreated)}</span>
+                                <span>📅 {formatTimestamp(item.date || item.createdAt || item.created_at || item.timestamp || item.dateCreated)}</span>
                                 {item.location && (
                                   <span>📍 {item.location}</span>
                                 )}
@@ -323,6 +461,175 @@ export default function ProfilePage() {
           )}
         </div>
       </div>
+      
+      {/* Edit Modal */}
+      {editModalOpen && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+          <div className="bg-white rounded-lg shadow-xl max-w-lg w-full mx-4 max-h-[90vh] overflow-y-auto">
+            <div className="p-6">
+              <div className="flex justify-between items-center mb-4">
+                <h2 className="text-xl font-semibold text-gray-900">Edit Post</h2>
+                <button
+                  onClick={handleCloseEditModal}
+                  className="text-gray-400 hover:text-gray-600 transition-colors"
+                >
+                  <X className="w-6 h-6" />
+                </button>
+              </div>
+              
+              <div className="space-y-4">
+                {/* Title */}
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Title *
+                  </label>
+                  <input
+                    type="text"
+                    value={editFormData.title}
+                    onChange={(e) => handleFormChange('title', e.target.value)}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                    placeholder="Enter title..."
+                  />
+                </div>
+                
+                {/* Description */}
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Description
+                  </label>
+                  <textarea
+                    value={editFormData.description}
+                    onChange={(e) => handleFormChange('description', e.target.value)}
+                    rows={3}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-none"
+                    placeholder="Enter description..."
+                  />
+                </div>
+                
+                {/* Category */}
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Category
+                  </label>
+                  <select
+                    value={editFormData.category}
+                    onChange={(e) => handleFormChange('category', e.target.value)}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  >
+                    <option value="">Select category</option>
+                    <option value="electronics">Electronics</option>
+                    <option value="stationery">Stationery</option>
+                    <option value="clothing">Clothing</option>
+                    <option value="documents">Documents</option>
+                    <option value="wallets">Wallets</option>
+                    <option value="keys/cards">Keys/Cards</option>
+                    <option value="accessories">Accessories</option>
+                    <option value="other">Other</option>
+                  </select>
+                </div>
+                
+                {/* Location */}
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Location
+                  </label>
+                  <select
+                    value={editFormData.location}
+                    onChange={(e) => handleFormChange('location', e.target.value)}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  >
+                    <option value="">Select location</option>
+                    <option value="OGGB">OGGB</option>
+                    <option value="Engineering Building">Engineering Building</option>
+                    <option value="Arts and Education Building">Arts and Education Building</option>
+                    <option value="Kate Edgar">Kate Edgar</option>
+                    <option value="Law Building">Law Building</option>
+                    <option value="General Library">General Library</option>
+                    <option value="Biology Building">Biology Building</option>
+                    <option value="Science Centre">Science Centre</option>
+                    <option value="Clock Tower">Clock Tower</option>
+                    <option value="Old Government House">Old Government House</option>
+                    <option value="Hiwa Recreation Centre">Hiwa Recreation Centre</option>
+                    <option value="Bioengineering Building">Bioengineering Building</option>
+                  </select>
+                </div>
+                
+                {/* Lost/Found Type */}
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Type *
+                  </label>
+                  <select
+                    value={editFormData.kind}
+                    onChange={(e) => handleFormChange('kind', e.target.value)}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  >
+                    <option value="">Select type</option>
+                    <option value="lost">Lost Item</option>
+                    <option value="found">Found Item</option>
+                  </select>
+                </div>
+                
+                {/* Image URL */}
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Image URL
+                  </label>
+                  <input
+                    type="url"
+                    value={editFormData.imageUrl}
+                    onChange={(e) => handleFormChange('imageUrl', e.target.value)}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                    placeholder="Enter image URL..."
+                  />
+                </div>
+                
+                {/* Date & Time */}
+                <div className="grid grid-cols-2 gap-3">
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                      Date
+                    </label>
+                    <input
+                      type="date"
+                      value={editFormData.date}
+                      onChange={(e) => handleFormChange('date', e.target.value)}
+                      className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                      Time
+                    </label>
+                    <input
+                      type="time"
+                      value={editFormData.time}
+                      onChange={(e) => handleFormChange('time', e.target.value)}
+                      className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                    />
+                  </div>
+                </div>
+              </div>
+              
+              {/* Action Buttons */}
+              <div className="flex justify-end gap-3 mt-6">
+                <button
+                  onClick={handleCloseEditModal}
+                  className="px-4 py-2 text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-md transition-colors"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={handleSaveEdit}
+                  className="px-4 py-2 text-white bg-blue-600 hover:bg-blue-700 rounded-md transition-colors"
+                >
+                  Save Changes
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## 📌 Description

This PR implements the Profile & History dashboard, allowing users to view and manage their activity in the application.
It introduces sections for My Posts and My Claims, each displaying status badges for better visibility.
Users can now edit or close their posts and navigate back to the post’s detail page directly from the dashboard.

It is needed because users previously had no central page to track their reported or claimed items.
This update improves usability and enhances user engagement by providing clear access to item history and actions.

---

## 🔗 Related Issue(s)

Closes #8

---

## ✅ Changes

- [✅] Major functionality added
- [✅] Bug fix
- [ ] Refactor
- [ ] Documentation update
- [✅] Other (please describe):

---

## 🧪 How to Test

1. Go to the Profile page after logging in (email: hello@gmail.com / password: hello1).
2. Verify that “My Posts” and “My Claims” sections display with correct status badges.
3. Try editing and closing a post — ensure changes are reflected in Firebase.
4. Click any post to navigate back to its detail page.
